### PR TITLE
Added PolyKinds pragma to allow GEq and GCompare instances for things of kind other than (* -> *).

### DIFF
--- a/src/Data/GADT/Compare.hs
+++ b/src/Data/GADT/Compare.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs, TypeOperators, RankNTypes, TypeFamilies, FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fno-warn-deprecated-flags #-}


### PR DESCRIPTION
I've tested this on GHC 7.8.1 with dependent-sum and dependent-map; everything seems to work out just fine.
